### PR TITLE
Add resize option

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ module.exports = function (options) {
         var opts = {
             file: file.path,
             lossy: options.lossy || false,
-            wait: true
+            wait: true,
+            resize: options.resize
         };
 
         kraken.upload(opts, function (data) {


### PR DESCRIPTION
Enabling this allowed me to pass the options for resizing the images through the API. Tested and it works well.

```
gulp.task('kraken', function () {
 gulp.src('_site/assets/images/**/*.*')
    .pipe(kraken({
      "kraken": {
        "key": "xxxx",
        "secret": "xxxx",
        "lossy": false,
        "resize": {
          "width": 100,
          "height": 100,
          "strategy": "auto"
        }
      }
    }));
});
```
