### PR TITLE
Update version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gulp-util": "^3.0.7",
     "kraken": "^0.3.3",
     "pretty-bytes": "^2.0.1",
-    "request": "^2.72.0",
+    "request": "^2.79.0",
     "through2-concurrent": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Update request version to 2.79 since it uses uuid module instead of node-uuid.

Some context: 
  [Request](https://github.com/request/request) has been updated to use uuid module, instead of the deprecated node-uuid.
please keep dependencies updated to avoid warnings when installing, and thanks for your great work 

👍 